### PR TITLE
Append each child as argument to React.createElement

### DIFF
--- a/src/React/Basic/Native/Internal.js
+++ b/src/React/Basic/Native/Internal.js
@@ -3,8 +3,7 @@ const RN = require("react-native")
 
 exports.unsafeCreateNativeElement = function(name){
   return function(props){
-    var children = (props.children) ? props.children : null;
-    if(children && children.length === 1){children = children[0]}
-    return React.createElement(RN[name], props, children)
+    var children = (props.children) ? props.children : [];
+    return React.createElement.apply(React, [RN[name], props].concat(children));
   }
 };


### PR DESCRIPTION
* Gets rid of warning that each child should have key
* Most of the time hiding this warning is what we want. Problem is in
  purescript-react-basic we do not differentiate between:

  `<Foo children={myChildren}/>`

  and

  `<Foo><Child1/><Child2/></Foo>`

  Since both will have the purescript api:

  `foo_ :: [Array JSX] -> JSX`

   We mostly use the purescript api to mean the latter JSX case
   wherein we don't want the warning to appear. So we translate the
   internal `unsafeCreateNativeElement` to reflect this.